### PR TITLE
Fix NoiseGen registry and generator injection

### DIFF
--- a/common/common-util/src/main/java/com/pg85/otg/constants/Constants.java
+++ b/common/common-util/src/main/java/com/pg85/otg/constants/Constants.java
@@ -107,6 +107,8 @@ public class Constants {
     public static final String MOD_BIOME_DICT_TAG_LABEL = "modtag.";
     public static final String MC_BIOME_DICT_TAG_LABEL = "mctag.";
 
+    public static final String MINECRAFT_NAMESPACE = "minecraft";
+
     public static final String LABEL_EXCLUDE = "-";
     public static final String MOD_LABEL_EXCLUDE = LABEL_EXCLUDE + MOD_LABEL;
     public static final String BIOME_CATEGORY_LABEL_EXCLUDE = LABEL_EXCLUDE + BIOME_CATEGORY_LABEL;

--- a/platforms/paper/src/main/java/com/pg85/otg/paper/OTGPlugin.java
+++ b/platforms/paper/src/main/java/com/pg85/otg/paper/OTGPlugin.java
@@ -22,6 +22,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.chunk.status.WorldGenContext;
 import net.minecraft.world.level.levelgen.NoiseGeneratorSettings;
 import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.CraftServer;
@@ -38,6 +39,7 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.concurrent.Executor;
 import java.util.concurrent.locks.ReentrantLock;
 
 
@@ -193,8 +195,6 @@ public class OTGPlugin extends JavaPlugin implements Listener {
                     new OTGBiomeProvider(OTGGen.getPreset().getFolderName(), world.getSeed(), false, false),
                     world.getSeed(),
                     settingReg.getOrThrow(settingsKey)
-                    //new RegistrySetBuilder().add(Registries.NOISE_SETTINGS, NoiseGeneratorSettings::bootstrap)
-                    // NoiseGeneratorSettings.bootstrap(settingReg)
             );
             // add the weird Spigot config; it was complaining about this
             // TODO: There's no conf field
@@ -205,15 +205,15 @@ public class OTGPlugin extends JavaPlugin implements Listener {
         }
 
         try {
-            Field finalGenerator = ObfuscationHelper.getField(ChunkMap.class, "generator", "u");
-            finalGenerator.setAccessible(true);
+            Field finalGeneratorContext = ObfuscationHelper.getField(ChunkMap.class, "worldGenContext", "S");
+            finalGeneratorContext.setAccessible(true);
 
-            finalGenerator.set(serverWorld.getChunkSource().chunkMap, OTGDelegate);
+            // Set the WorldGenContext because now they're using a record called WorldGenContext and that contains the generator
+            // - Frank
+            WorldGenContext theirWgc = (WorldGenContext) finalGeneratorContext.get(serverWorld.getChunkSource().chunkMap);
+            WorldGenContext ourWgc = new WorldGenContext(theirWgc.level(), OTGDelegate, theirWgc.structureManager(), theirWgc.lightEngine(), theirWgc.mainThreadExecutor(), theirWgc.unsavedListener());
 
-            /*Field pcmGen = ObfuscationHelper.getField(ChunkMap.class, "generator", "r");
-            pcmGen.setAccessible(true);
-
-            pcmGen.set(serverWorld.getChunkSource().chunkMap, OTGDelegate);*/
+            finalGeneratorContext.set(serverWorld.getChunkSource().chunkMap, ourWgc);
         } catch (ReflectiveOperationException ex) {
             ex.printStackTrace();
         }

--- a/platforms/paper/src/main/java/com/pg85/otg/paper/OTGPlugin.java
+++ b/platforms/paper/src/main/java/com/pg85/otg/paper/OTGPlugin.java
@@ -174,7 +174,7 @@ public class OTGPlugin extends JavaPlugin implements Listener {
             Registry<NoiseGeneratorSettings> settingReg = registryAccess.lookupOrThrow(Registries.NOISE_SETTINGS);
             // We do not actually take advantage of the vanilla noise settings/system so this will be set to default
             // - Frank
-            ResourceKey<NoiseGeneratorSettings> settingsKey = ResourceKey.create(Registries.NOISE_SETTINGS, ResourceLocation.withDefaultNamespace("overworld"));
+            ResourceKey<NoiseGeneratorSettings> settingsKey = ResourceKey.create(Registries.NOISE_SETTINGS, ResourceLocation.fromNamespaceAndPath(Constants.MINECRAFT_NAMESPACE, "overworld"));
 
             try {
                 frozen = ObfuscationHelper.getField(MappedRegistry.class, "frozen", "l");

--- a/platforms/paper/src/main/java/com/pg85/otg/paper/OTGPlugin.java
+++ b/platforms/paper/src/main/java/com/pg85/otg/paper/OTGPlugin.java
@@ -35,6 +35,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.World;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.concurrent.locks.ReentrantLock;
@@ -171,22 +172,28 @@ public class OTGPlugin extends JavaPlugin implements Listener {
         if (OTGGen.generator == null) {
             Field frozen;
             Registry<NoiseGeneratorSettings> settingReg = registryAccess.lookupOrThrow(Registries.NOISE_SETTINGS);
-            ResourceKey<NoiseGeneratorSettings> settingsKey = ResourceKey.create(Registries.NOISE_SETTINGS, ResourceLocation.fromNamespaceAndPath(Constants.MOD_ID_SHORT, "noise_settings"));
+            // We do not actually take advantage of the vanilla noise settings/system so this will be set to default
+            // - Frank
+            ResourceKey<NoiseGeneratorSettings> settingsKey = ResourceKey.create(Registries.NOISE_SETTINGS, ResourceLocation.withDefaultNamespace("overworld"));
 
             try {
-                frozen = ObfuscationHelper.getField(MappedRegistry.class, "frozen", "ca");
+                frozen = ObfuscationHelper.getField(MappedRegistry.class, "frozen", "l");
                 frozen.setAccessible(true);
                 frozen.set(settingReg, false);
             } catch (NoSuchFieldException | IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
+            // Make sure the registry actually contains the key for noise settings.
+            // - Frank
+            if (!settingReg.containsKey(settingsKey)) {
+                OTG.getEngine().getLogger().log(LogLevel.FATAL, LogCategory.MAIN, "Noise settings are not registered for world " + world.getName());
+            }
             OTGDelegate = new OTGNoiseChunkGenerator(
                     OTGGen.getPreset().getFolderName(),
                     new OTGBiomeProvider(OTGGen.getPreset().getFolderName(), world.getSeed(), false, false),
                     world.getSeed(),
-                    // TODO: Does this go around the freezing?
                     settingReg.getOrThrow(settingsKey)
-                    // new RegistrySetBuilder().add(Registries.NOISE_SETTINGS, NoiseGeneratorSettings::bootstrap)
+                    //new RegistrySetBuilder().add(Registries.NOISE_SETTINGS, NoiseGeneratorSettings::bootstrap)
                     // NoiseGeneratorSettings.bootstrap(settingReg)
             );
             // add the weird Spigot config; it was complaining about this
@@ -198,7 +205,6 @@ public class OTGPlugin extends JavaPlugin implements Listener {
         }
 
         try {
-            // Field finalGenerator = ObfuscationHelper.getField(ChunkMap.class, "generator", "t");
             Field finalGenerator = ObfuscationHelper.getField(ChunkMap.class, "generator", "u");
             finalGenerator.setAccessible(true);
 

--- a/platforms/paper/src/main/java/com/pg85/otg/paper/gen/OTGNoiseChunkGenerator.java
+++ b/platforms/paper/src/main/java/com/pg85/otg/paper/gen/OTGNoiseChunkGenerator.java
@@ -410,8 +410,6 @@ public class OTGNoiseChunkGenerator extends ChunkGenerator {
     // }
 
     // Carvers: Caves and ravines
-    // TODO: Re-implement carvers, or find some way to get new (much more complex) vanilla cavegen to do the work for us
-
     @Override
     public void applyCarvers(WorldGenRegion chunkRegion, long seed, RandomState noiseConfig, BiomeManager biomeManager, StructureManager structureAccess, ChunkAccess chunk) {
         BiomeManager biomeManager1 = biomeManager.withDifferentSource((x, y, z) -> super.biomeSource.getNoiseBiome(x, y, z, noiseConfig.sampler()));


### PR DESCRIPTION
- Mojang has changed they way their NoiseGen registry works. However, we don't actually need to use our own registries for this, so I have changed it to use the vanilla overworld.
- I have made sure for the future if these names change that we assert that the overworld registry exists.
- Lastly, I have fixed the process of injecting the chunk generator, as Mojang is now keeping that in a record. This will grab the record, and make a new one with the same data except for our chunk generator.
- I also got rid of some old comments that no longer are needed.